### PR TITLE
add 'Arduino LLC (www.arduino.cc)' manufacurer to target-service port

### DIFF
--- a/server/target/target-service.js
+++ b/server/target/target-service.js
@@ -11,7 +11,7 @@ let arduinoDevices;
 
 
 const isValidPort = (port) =>
-    port.manufacturer === 'Arduino (www.arduino.cc)'
+    (port.manufacturer === 'Arduino (www.arduino.cc)' || port.manufacturer === 'Arduino LLC (www.arduino.cc)')
     && port.vendorId === '2341'
     && port.productId === '0043';
 


### PR DESCRIPTION
[ { comName: 'COM3',
    manufacturer: 'Arduino LLC (www.arduino.cc)',
    serialNumber: '....',
    pnpId: '....',
    locationId: 'Port_#0003.Hub_#0001',
    vendorId: '2341',
    productId: '0043' } ]

I have "Arduino LLC (www.arduino.cc)" instead of "Arduino (www.arduino.cc)"